### PR TITLE
Support for different sized grids

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,40 +10,10 @@
   </head>
   <body>
     <h1 class="heading"></h1>
+    <form class="grid-size">
+    <input type="range" name="gridSize" id="gridSize" value="4" min="3" max="10" step="1">
+    </form>
     <main class="frame grid">
-      <button class="tile tile--1" disabled style="--area: A;">1</button>
-      <button class="tile tile--2" disabled style="--area: B;">2</button>
-      <button class="tile tile--3" disabled style="--area: C;">3</button>
-      <button class="tile tile--4" disabled style="--area: D;">4</button>
-      <button class="tile tile--5" disabled style="--area: E;">5</button>
-      <button class="tile tile--6" disabled style="--area: F;">6</button>
-      <button class="tile tile--7" disabled style="--area: G;">7</button>
-      <button class="tile tile--8" disabled style="--area: H;">8</button>
-      <button class="tile tile--9" disabled style="--area: I;">9</button>
-      <button class="tile tile--10" disabled style="--area: J;">10</button>
-      <button class="tile tile--11" disabled style="--area: K;">11</button>
-      <button class="tile tile--12" disabled style="--area: L;">12</button>
-      <button class="tile tile--13" disabled style="--area: M;">13</button>
-      <button class="tile tile--14" disabled style="--area: N;">14</button>
-      <button class="tile tile--15" disabled style="--area: O;">15</button>
-      <div class="tile tile--empty" style="--area: P;"></div>
-
-      <div class="tile-background" style="--area: A;"></div>
-      <div class="tile-background" style="--area: B;"></div>
-      <div class="tile-background" style="--area: C;"></div>
-      <div class="tile-background" style="--area: D;"></div>
-      <div class="tile-background" style="--area: E;"></div>
-      <div class="tile-background" style="--area: F;"></div>
-      <div class="tile-background" style="--area: G;"></div>
-      <div class="tile-background" style="--area: H;"></div>
-      <div class="tile-background" style="--area: I;"></div>
-      <div class="tile-background" style="--area: J;"></div>
-      <div class="tile-background" style="--area: K;"></div>
-      <div class="tile-background" style="--area: L;"></div>
-      <div class="tile-background" style="--area: M;"></div>
-      <div class="tile-background" style="--area: N;"></div>
-      <div class="tile-background" style="--area: O;"></div>
-      <div class="tile-background" style="--area: P;"></div>
     </main>
     <div>
       <button class="newGame"type="button">Play New Game</button>

--- a/puzzle.js
+++ b/puzzle.js
@@ -1,132 +1,254 @@
 // @ts-check
 'use strict';
 
-// Init animateCSSGrid dependency
-const grid = document.querySelector('.grid');
-const { forceGridAnimation } = animateCSSGrid.wrapGrid(grid);
+(function () {
+  const gridSizeRange = document.querySelector('#gridSize');
 
-const tiles = Array.from(document.querySelectorAll('.tile'));
-const emptyTile = document.querySelector('.tile--empty');
+  let gridSize = 4;
 
-const heading = document.querySelector('.heading');
-
-// Get congratulations heading
-const newGame = document.querySelector(".newGame");
-newGame.addEventListener("click", event => location.reload());
-
-
-const areaKeys = {
-  A: ['B', 'E'],
-  B: ['A', 'C', 'F'],
-  C: ['B', 'D', 'G'],
-  D: ['C', 'H'],
-  E: ['F', 'A', 'I'],
-  F: ['E', 'G', 'B', 'J'],
-  G: ['F', 'H', 'C', 'K'],
-  H: ['G', 'D', 'L'],
-  I: ['J', 'E', 'M'],
-  J: ['I', 'K', 'F', 'N'],
-  K: ['J', 'L', 'G', 'O'],
-  L: ['K', 'H', 'P'],
-  M: ['N', 'I'],
-  N: ['M', 'O', 'J'],
-  O: ['N', 'P', 'K'],
-  P: ['O', 'L'],
-};
-
-// Add click listener to all tiles
-tiles.map((tile) => {
-  tile.addEventListener('click', (event) => {
-    // Grab the grid area set on the clicked tile and empty tile
-    const tileArea = tile.style.getPropertyValue('--area');
-    const emptyTileArea = emptyTile.style.getPropertyValue('--area');
-
-    // Swap the empty tile with the clicked tile
-    emptyTile.style.setProperty('--area', tileArea);
-    tile.style.setProperty('--area', emptyTileArea);
-
-    // Animate the tiles
-    forceGridAnimation();
-
-    // Unlock and lock tiles
-    unlockTiles(tileArea);
+  gridSizeRange.addEventListener('mouseup', () => {
+    gridSize = parseInt(gridSizeRange.value);
+    main();
   });
-});
 
-const unlockTiles = (currentTileArea) => {
-  // Cycle through all the tiles and check which should be disabled and enabled
-  tiles.map((tile) => {
-    const tileArea = tile.style.getPropertyValue('--area');
+  //const gridSize = 10;
 
-    // Check if that areaKey has the tiles area in it's values
-    // .trim() is needed because the animation lib formats the styles attribute
-    if (areaKeys[currentTileArea.trim()].includes(tileArea.trim())) {
-      tile.disabled = false;
-    } else {
-      tile.disabled = true;
+  const grid = document.querySelector('.grid');
+  const heading = document.querySelector('.heading');
+  const newGame = document.querySelector('.newGame');
+
+  // Init animateCSSGrid dependency
+  const { forceGridAnimation } = animateCSSGrid.wrapGrid(grid);
+
+  const setRootProperty = (property, value) => {
+    const root = document.documentElement;
+    root.style.setProperty(property, value);
+  };
+
+  // Find out what row a tile is in
+  const getAreaRow = (tilePosition, gridSize) => {
+    return Math.ceil(tilePosition++ / gridSize);
+  };
+
+  // Find out what column a tile is in
+  const getAreaColumn = (tilePosition, areaRow, gridSize) => {
+    return tilePosition - (areaRow - 1) * gridSize;
+  };
+
+  // Fn to create an object where the key
+  const getAreaKeys = (gridSize) => {
+    const gridPositions = Math.pow(gridSize, 2);
+    const areaKeys = [];
+    for (let index = 1; index < gridPositions + 1; index++) {
+      const areaRow = getAreaRow(index, gridSize);
+      let leftPos, rightPos, topPos, bottomPos;
+      if (getAreaRow(index - 1, gridSize) === areaRow) {
+        leftPos = index - 1;
+      }
+
+      if (getAreaRow(index + 1, gridSize) === areaRow) {
+        rightPos = index + 1;
+      }
+
+      if (index - gridSize > 0) {
+        topPos = index - gridSize;
+      }
+
+      if (index + gridSize <= gridPositions) {
+        bottomPos = index + gridSize;
+      }
+
+      const values = [leftPos, rightPos, topPos, bottomPos].filter(Boolean);
+      areaKeys[index] = values;
     }
-  });
+    return areaKeys;
+  };
 
-  // Check if the tiles are in the right order
-  isComplete(tiles);
-};
+  const getAreaKey = (areaRowColumn, gridSize) => {
+    let [row, column] = areaRowColumn.trim().split('/').map(Number);
+    return --row * gridSize + column;
+  };
 
-const isComplete = (tiles) => {
-  // Get all the current tile area values
-  const currentTilesString = tiles
-    .map((tile) => tile.style.getPropertyValue('--area').trim())
-    .toString();
+  const getTileColor = (row, column) => {
+    if (
+      (row % 2 == 1 && column % 2 == 1) ||
+      (row % 2 == 0 && column % 2 == 0)
+    ) {
+      return 'tile--color1';
+    } else {
+      return 'tile--color2';
+    }
+  };
 
-  // Compare the current tiles with the areaKeys keys
-  if (currentTilesString == Object.keys(areaKeys).toString()) {
-    heading.innerHTML = 'Nicely Done!';
-    heading.style = `display:block; animation: popIn .3s cubic-bezier(0.68, -0.55, 0.265, 1.55);`;
+  const generateGridInDOM = (grid, numberOfTiles, gridSize) => {
+    // Remove existing grid
+    while (grid.firstChild) {
+      grid.removeChild(grid.firstChild);
+    }
+    // insert tiles
+    for (let index = 1; index < numberOfTiles + 1; index++) {
+      let areaRow = getAreaRow(index, gridSize);
+      let areaColumn = getAreaColumn(index, areaRow, gridSize);
+      let tileColor = getTileColor(areaRow, areaColumn);
+      // @TODO DOM insertions are slow, build as string and then insert in DOM at end.
+      grid.insertAdjacentHTML(
+        'beforeend',
+        `<button class="tile tile--${index} ${tileColor}" disabled style="--area: ${areaRow}/${areaColumn};">${index}</button>
+    <div class="tile-background" style="--area: ${areaRow}/${areaColumn};"></div>`
+      );
+    }
+    // insert empty tile as last sibling
+    grid.insertAdjacentHTML(
+      `beforeend`,
+      `<div class="tile tile--empty" style="--area: ${gridSize}/${gridSize};"></div>
+    <div class="tile-background" style="--area: ${gridSize}/${gridSize};"></div>`
+    );
+  };
+
+  const sizeTileFont = (gridSize) => {
+    //Size font to tileheight
+    let fontSize;
+    if (gridSize < 11) {
+      fontSize = (80 / gridSize) * 0.6;
+    } else {
+      fontSize = (80 / gridSize) * 0.4;
+    }
+
+    setRootProperty('--font-size', `${fontSize}vmin`);
+  };
+
+  // Use event delegation: .grid and event.target
+  const attachTilesClickHandler = (tiles, emptyTile, areaKeys) => {
+    tiles.map((tile) => {
+      tile.addEventListener('click', (event) => {
+        // Grab the grid area set on the clicked tile and empty tile
+        const tileArea = tile.style.getPropertyValue('--area');
+        const emptyTileArea = emptyTile.style.getPropertyValue('--area');
+
+        // Swap the empty tile with the clicked tile
+        emptyTile.style.setProperty('--area', tileArea);
+        tile.style.setProperty('--area', emptyTileArea);
+
+        // Animate the tiles
+        forceGridAnimation();
+
+        const currentTileArea = getAreaKey(tileArea, gridSize);
+
+        // Unlock and lock tiles
+        unlockTiles(tiles, currentTileArea, areaKeys, gridSize);
+      });
+    });
+  };
+
+  const unlockTiles = (tiles, currentTileArea, areaKeys, gridSize) => {
+    // Cycle through all the tiles and check which should be disabled and enabled
+
+    tiles.map((tile) => {
+      const tileArea = tile.style.getPropertyValue('--area');
+
+      // Check if that areaKey has the tiles area in it's values
+      // .trim() is needed because the animation lib formats the styles attribute
+
+      const areaKey = getAreaKey(tileArea, gridSize);
+
+      if (areaKeys[currentTileArea].includes(areaKey)) {
+        tile.disabled = false;
+      } else {
+        tile.disabled = true;
+      }
+    });
+
+    // Check if the tiles are in the right order
+    isComplete(tiles, areaKeys);
+  };
+
+  const isComplete = (tiles, areaKeys) => {
+    // Get all the current tile area values
+    const currentTilesString = tiles
+      .map((tile) => tile.style.getPropertyValue('--area').trim())
+      .toString();
+
+    // Compare the current tiles with the areaKeys keys
+    if (currentTilesString == Object.keys(areaKeys).toString()) {
+      heading.innerHTML = 'Nicely Done!';
+      heading.style = `display:block; animation: popIn .3s cubic-bezier(0.68, -0.55, 0.265, 1.55);`;
+    }
+  };
+
+  // Inversion calculator
+  const inversionCount = (array) => {
+    // Using the reduce function to run through all items in the array
+    // Each item in the array is checked against everything before it
+    // This will return a new array with each intance of an item appearing before it's original predecessor
+    return array.reduce((accumulator, current, index, array) => {
+      return array
+        .slice(index)
+        .filter((item) => {
+          return item < current;
+        })
+        .map((item) => {
+          return [current, item];
+        })
+        .concat(accumulator);
+    }, []).length;
+  };
+
+  // Randomise tiles
+  const shuffledKeys = (keys) => {
+    return Object.keys(keys)
+      .map(Number)
+      .sort(() => 0.5 - Math.random());
+  };
+
+  // Main
+  function main() {
+    const numberOfTiles = Math.pow(gridSize, 2) - 1; //?
+
+    //@TODO — just reset game instead of reloading
+    newGame.addEventListener('click', (event) => location.reload());
+    setRootProperty('--grid-size', gridSize);
+
+    generateGridInDOM(grid, numberOfTiles, gridSize);
+
+    const tiles = Array.from(document.querySelectorAll('.tile'));
+    const emptyTile = document.querySelector('.tile--empty');
+
+    //@TODO size in relative units or recalculate, so it updates on viewport resize
+    sizeTileFont(gridSize);
+
+    const areaKeys = getAreaKeys(gridSize);
+
+    attachTilesClickHandler(tiles, emptyTile, areaKeys);
+
+    setTimeout(() => {
+      // Begin with our in order area keys
+      let startingAreas = Object.keys(areaKeys).map(Number);
+
+      // Use the inversion function to check if the keys will be solveable or not shuffled
+      // Shuffle the keys until they are solvable
+      while (
+        inversionCount(startingAreas) % 2 == 1 ||
+        inversionCount(startingAreas) == 0
+      ) {
+        startingAreas = shuffledKeys(areaKeys); //?
+      }
+
+      // Apply shuffled areas
+      tiles.map((tile, index) => {
+        let areaRow = getAreaRow(startingAreas[index], gridSize);
+        let areaColumn = getAreaColumn(startingAreas[index], areaRow, gridSize);
+        tile.style.setProperty('--area', `${areaRow}/${areaColumn}`);
+      });
+
+      // Initial shuffle animation
+      forceGridAnimation();
+
+      // Unlock and lock tiles
+      const emptyTileArea = emptyTile.style.getPropertyValue('--area');
+      const emptyTileAreaKey = getAreaKey(emptyTileArea, gridSize);
+
+      unlockTiles(tiles, emptyTileAreaKey, areaKeys, gridSize);
+    }, 2000);
   }
-};
-
-// Inversion calculator
-const inversionCount = (array) => {
-  // Using the reduce function to run through all items in the array
-  // Each item in the array is checked against everything before it
-  // This will return a new array with each intance of an item appearing before it's original predecessor
-  return array.reduce((accumulator, current, index, array) => {
-    return array
-      .slice(index)
-      .filter((item) => {
-        return item < current;
-      })
-      .map((item) => {
-        return [current, item];
-      })
-      .concat(accumulator);
-  }, []).length;
-};
-
-// Randomise tiles
-const shuffledKeys = (keys) =>
-  Object.keys(keys).sort(() => 0.5 - Math.random());
-
-setTimeout(() => {
-  // Begin with our in order area keys
-  let startingAreas = Object.keys(areaKeys);
-
-  // Use the inversion function to check if the keys will be solveable or not shuffled
-  // Shuffle the keys until they are solvable
-  while (
-    inversionCount(startingAreas) % 2 == 1 ||
-    inversionCount(startingAreas) == 0
-  ) {
-    startingAreas = shuffledKeys(areaKeys);
-  }
-
-  // Apply shuffled areas
-  tiles.map((tile, index) => {
-    tile.style.setProperty('--area', startingAreas[index]);
-  });
-
-  // Initial shuffle animation
-  forceGridAnimation();
-
-  // Unlock and lock tiles
-  unlockTiles(emptyTile.style.getPropertyValue('--area'));
-}, 2000);
+  main();
+})();

--- a/style.css
+++ b/style.css
@@ -10,8 +10,15 @@
   --tile--2-highlight: hsl(45, 100%, 70%);
   --tile--2-shadow: hsl(45, 100%, 30%);
   --border-thickness: 3px;
+  /* --font-size: calc(1rem + (10vmin / (var(--grid-size) * 0.5))); */
   --grid-size: 4;
 }
+
+/* @media screen and (min-width: 800px) {
+  :root {
+    --font-size: calc(1rem + 10vmin);
+  }
+} */
 
 @font-face {
   font-family: 'LibreClarendonWide-Medium';
@@ -35,15 +42,21 @@ body {
   );
   color: hsl(0, 0%, 1%);
   font-family: LibreClarendonWide-Medium, american typewriter, serif;
-  font-size: calc(1rem + 10vmin);
+  font-size: var(--font-size);
   touch-action: none; /* disable zoom on touch devices */
+}
+
+.grid-size {
+  display:flex;
+  justify-content: center;
+  margin: 2vmin 0;
 }
 
 main {
   margin: 0 auto;
   width: 80vmin;
   height: 80vmin;
-  margin-top: calc((100vh - 88vmin) / 2);
+  /*margin-top: calc((100vh - 88vmin) / 2);*/
   /* @TODO 80vmin + 2*4vmin from padding, should calc with css properties */
 }
 
@@ -62,11 +75,6 @@ main {
 
 .grid {
   display: grid;
-  grid-template-areas:
-    "A B C D"
-    "E F G H"
-    "I J K L"
-    "M N O P";
   grid-template-columns: repeat(var(--grid-size), 1fr);
 }
 
@@ -87,7 +95,7 @@ main {
 .tile {
   -webkit-appearance: none;
   -moz-appearance: none;
-  grid-area: var(--area, auto);
+  grid-area: var(--area);
   margin: 0;
   padding: 0;
   letter-spacing: -2px;
@@ -115,13 +123,7 @@ main {
   grid-area: var(--area, auto);
 }
 
-.tile--1,
-.tile--3,
-.tile--6,
-.tile--8,
-.tile--9,
-.tile--11,
-.tile--14 {
+.tile--color1 {
   background-color: var(--tile--1-color);
   border: var(--border-thickness) solid;
   border-top-color: var(--tile--1-highlight);
@@ -130,14 +132,7 @@ main {
   border-left-color: var(--tile--1-highlight);
 }
 
-.tile--2,
-.tile--4,
-.tile--5,
-.tile--7,
-.tile--10,
-.tile--12,
-.tile--13,
-.tile--15 {
+.tile--color2 {
   background-color: var(--tile--2-color);
   border: var(--border-thickness) solid;
   border-top-color: var(--tile--2-highlight);


### PR DESCRIPTION
- supports different sized grids, merely by setting the `gridSize` variable
- `font-size` is calculated and set in relative units (`vmin`), so it will scale as user resizes the viewport. Currently supports double digits numbers as a maximum. This could be easily adjusted but it would require a different font (or at least weight) and it would also make sense that the puzzle would be sized up to  `100vmin`. 
- tile color and `areaKeys` map (keeps track of valid tile moves for each position) are no longer hardcoded and get calculated
- using `grid-template-areas` didn't seem to support using number for the areas, so I switched to using `grid-area` and using a _row / column_ calculation
- ⚠️ performance wasn't a consideration, a quick win would be to minimize DOM insertion by just concatenating each to a string, and then inserting it at the end
- ⚠️ not addressed: isComplete check, making sure puzzle is solvable